### PR TITLE
Update to Cake 0.23.0, update implementation of ICakeEngine

### DIFF
--- a/src/Cake.Module.Shared/Cake.Module.Shared.csproj
+++ b/src/Cake.Module.Shared/Cake.Module.Shared.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.2" />
-    <PackageReference Include="Cake.Common" Version="0.22.2" />
+    <PackageReference Include="Cake.Core" Version="0.23.0" />
+    <PackageReference Include="Cake.Common" Version="0.23.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.Module.Shared/CakeEngineBase.cs
+++ b/src/Cake.Module.Shared/CakeEngineBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Cake.Core;
 
 namespace Cake.Module.Shared
@@ -40,15 +41,17 @@ namespace Cake.Module.Shared
         }
 
         /// <summary>
-        ///     Runs the specified target using the specified <see cref="T:Cake.Core.IExecutionStrategy" />.
+        /// Runs the specified target using the specified <see cref="T:Cake.Core.IExecutionStrategy" />.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="strategy">The execution strategy.</param>
         /// <param name="target">The target to run.</param>
-        /// <returns>The resulting report.</returns>
-        public CakeReport RunTarget(ICakeContext context, IExecutionStrategy strategy, string target)
+        /// <returns>
+        /// The resulting report.
+        /// </returns>
+        public Task<CakeReport> RunTargetAsync(ICakeContext context, IExecutionStrategy strategy, string target)
         {
-            return _engine.RunTarget(context, strategy, target);
+            return _engine.RunTargetAsync(context, strategy, target);
         }
 
         /// <summary>

--- a/src/Cake.MyGet.Module/Cake.MyGet.Module.csproj
+++ b/src/Cake.MyGet.Module/Cake.MyGet.Module.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.2" />
-    <PackageReference Include="Cake.Common" Version="0.22.2" />
+    <PackageReference Include="Cake.Core" Version="0.23.0" />
+    <PackageReference Include="Cake.Common" Version="0.23.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.TFBuild.Module/Cake.TFBuild.Module.csproj
+++ b/src/Cake.TFBuild.Module/Cake.TFBuild.Module.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.2" />
-    <PackageReference Include="Cake.Common" Version="0.22.2" />
+    <PackageReference Include="Cake.Core" Version="0.23.0" />
+    <PackageReference Include="Cake.Common" Version="0.23.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.TeamCity.Module/Cake.TeamCity.Module.csproj
+++ b/src/Cake.TeamCity.Module/Cake.TeamCity.Module.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.2" />
-    <PackageReference Include="Cake.Common" Version="0.22.2" />
+    <PackageReference Include="Cake.Core" Version="0.23.0" />
+    <PackageReference Include="Cake.Common" Version="0.23.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.TravisCI.Module/Cake.TravisCI.Module.csproj
+++ b/src/Cake.TravisCI.Module/Cake.TravisCI.Module.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.2" />
-    <PackageReference Include="Cake.Common" Version="0.22.2" />
+    <PackageReference Include="Cake.Core" Version="0.23.0" />
+    <PackageReference Include="Cake.Common" Version="0.23.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">


### PR DESCRIPTION
This updates the Cake references to 0.23.0 and updates the implementation of `ICakeEngine` to address the problem described in GH-6