### PR TITLE
Fix Environment Variable check for TeamCity Log

### DIFF
--- a/src/Cake.TeamCity.Module/TeamCityLog.cs
+++ b/src/Cake.TeamCity.Module/TeamCityLog.cs
@@ -16,7 +16,7 @@ namespace Cake.TeamCity.Module
 
         public void Write(Verbosity verbosity, LogLevel level, string format, params object[] args)
         {
-            if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("TF_BUILD")))
+            if (!string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("TEAMCITY_VERSION")))
             {
                 switch (level)
                 {


### PR DESCRIPTION
Was previously looking for TF_BUILD which is for TFS/VSTS Environments.