### PR TITLE
Upgrade to Cake 0.28

### DIFF
--- a/src/Cake.Module.Shared/Cake.Module.Shared.csproj
+++ b/src/Cake.Module.Shared/Cake.Module.Shared.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.24.0" />
-    <PackageReference Include="Cake.Common" Version="0.24.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
+    <PackageReference Include="Cake.Common" Version="0.28.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.Module.Shared/CakeEngineBase.cs
+++ b/src/Cake.Module.Shared/CakeEngineBase.cs
@@ -15,9 +15,21 @@ namespace Cake.Module.Shared
         /// <summary>Registers a new task.</summary>
         /// <param name="name">The name of the task.</param>
         /// <returns>A <see cref="T:Cake.Core.CakeTaskBuilder`1" />.</returns>
-        public CakeTaskBuilder<ActionTask> RegisterTask(string name)
+        public CakeTaskBuilder RegisterTask(string name)
         {
             return _engine.RegisterTask(name);
+        }
+
+        /// <inheritdoc />
+        public void RegisterSetupAction(Action<ISetupContext> action)
+        {
+            _engine.RegisterSetupAction(action);
+        }
+
+        /// <inheritdoc />
+        public void RegisterSetupAction<TData>(Func<ISetupContext, TData> action) where TData : class
+        {
+            _engine.RegisterSetupAction(action);
         }
 
         /// <summary>
@@ -36,6 +48,12 @@ namespace Cake.Module.Shared
         /// </summary>
         /// <param name="action">The action to be executed.</param>
         public void RegisterTeardownAction(Action<ITeardownContext> action)
+        {
+            _engine.RegisterTeardownAction(action);
+        }
+
+        /// <inheritdoc />
+        public void RegisterTeardownAction<TData>(Action<ITeardownContext, TData> action) where TData : class
         {
             _engine.RegisterTeardownAction(action);
         }
@@ -64,6 +82,12 @@ namespace Cake.Module.Shared
             _engine.RegisterTaskSetupAction(action);
         }
 
+        /// <inheritdoc />
+        public void RegisterTaskSetupAction<TData>(Action<ITaskSetupContext, TData> action) where TData : class
+        {
+            _engine.RegisterTaskSetupAction(action);
+        }
+
         /// <summary>
         ///     Allows registration of an action that's executed after each task has been run.
         ///     If a task setup action or a task fails with or without recovery, the specified task teardown action will still be
@@ -75,9 +99,18 @@ namespace Cake.Module.Shared
             _engine.RegisterTaskTeardownAction(action);
         }
 
+        /// <inheritdoc />
+        public void RegisterTaskTeardownAction<TData>(Action<ITaskTeardownContext, TData> action) where TData : class
+        {
+            _engine.RegisterTaskTeardownAction(action);
+        }
+
+        /// <inheritdoc />
+        IReadOnlyList<ICakeTaskInfo> ICakeEngine.Tasks => _engine.Tasks;
+
         /// <summary>Gets all registered tasks.</summary>
         /// <value>The registered tasks.</value>
-        public IReadOnlyList<CakeTask> Tasks => _engine.Tasks;
+        public IReadOnlyList<ICakeTaskInfo> Tasks => _engine.Tasks;
 
         /// <summary>Raised during setup before any tasks are run.</summary>
         public event EventHandler<SetupEventArgs> Setup

--- a/src/Cake.MyGet.Module/Cake.MyGet.Module.csproj
+++ b/src/Cake.MyGet.Module/Cake.MyGet.Module.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.24.0" />
-    <PackageReference Include="Cake.Common" Version="0.24.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
+    <PackageReference Include="Cake.Common" Version="0.28.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.MyGet.Module/MyGetEngine.cs
+++ b/src/Cake.MyGet.Module/MyGetEngine.cs
@@ -11,7 +11,7 @@ namespace Cake.MyGet.Module
         private ICakeLog _log;
         private System.Diagnostics.Stopwatch _stopwatch;
 
-        public MyGetEngine(ICakeLog log) : base(new CakeEngine(log))
+        public MyGetEngine(ICakeDataService dataService, ICakeLog log) : base(new CakeEngine(dataService, log))
         {
             _log = log;
             //_engine.Setup += BuildSetup;

--- a/src/Cake.TFBuild.Module/Cake.TFBuild.Module.csproj
+++ b/src/Cake.TFBuild.Module/Cake.TFBuild.Module.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.24.0" />
-    <PackageReference Include="Cake.Common" Version="0.24.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
+    <PackageReference Include="Cake.Common" Version="0.28.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.TFBuild.Module/TFBuildEngine.cs
+++ b/src/Cake.TFBuild.Module/TFBuildEngine.cs
@@ -17,8 +17,9 @@ namespace Cake.TFBuild.Module
         /// <summary>
         /// Initializes a new instance of the <see cref="TFBuildEngine"/> type.
         /// </summary>
+        /// <param name="dataService"></param>
         /// <param name="log">The log.</param>
-        public TFBuildEngine(ICakeLog log) : base(new CakeEngine(log))
+        public TFBuildEngine(ICakeDataService dataService, ICakeLog log) : base(new CakeEngine(dataService, log))
         {
             _engine.Setup += BuildSetup;
             _engine.TaskSetup += OnTaskSetup;

--- a/src/Cake.TeamCity.Module/Cake.TeamCity.Module.csproj
+++ b/src/Cake.TeamCity.Module/Cake.TeamCity.Module.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.24.0" />
-    <PackageReference Include="Cake.Common" Version="0.24.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
+    <PackageReference Include="Cake.Common" Version="0.28.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.TeamCity.Module/TeamCityEngine.cs
+++ b/src/Cake.TeamCity.Module/TeamCityEngine.cs
@@ -11,7 +11,7 @@ namespace Cake.TeamCity.Module
 {
     public sealed class TeamCityEngine : CakeEngineBase
     {
-        public TeamCityEngine(ICakeLog log) : base(new CakeEngine(log))
+        public TeamCityEngine(ICakeDataService dataService, ICakeLog log) : base(new CakeEngine(dataService, log))
         {
             _engine.Setup += OnBuildSetup;
             _engine.TaskSetup += OnTaskSetup;

--- a/src/Cake.TravisCI.Module/Cake.TravisCI.Module.csproj
+++ b/src/Cake.TravisCI.Module/Cake.TravisCI.Module.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.24.0" />
-    <PackageReference Include="Cake.Common" Version="0.24.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
+    <PackageReference Include="Cake.Common" Version="0.28.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.TravisCI.Module/TravisCIEngine.cs
+++ b/src/Cake.TravisCI.Module/TravisCIEngine.cs
@@ -12,7 +12,7 @@ namespace Cake.TravisCI.Module
     public class TravisCIEngine : CakeEngineBase
     {
         private readonly string _buildMessage;
-        public TravisCIEngine(IConsole console) : base(new CakeEngine(new RawBuildLog(console)))
+        public TravisCIEngine(ICakeDataService dataService, IConsole console) : base(new CakeEngine(dataService, new RawBuildLog(console)))
         {
             _engine.Setup += OnBuildSetup;
             _engine.TaskSetup += OnTaskSetup;


### PR DESCRIPTION
- Implement new methods that were added to ICakeEngine

Breaking changes in Cake.Core mean module built against earlier versions won't work with Cake 0.28+

Fixes #15